### PR TITLE
Used generator to parse/stream *.osm.pbf files for increased memory efficiency 

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,16 @@ dri.merge_multi_shp(subregion_names, layer=layer_name, update_shp_zip=False,
 You could also set `data_dir=customised_data_dir` to save the downloaded **.shp.zip** files; or `output_dir=customised_data_dir` to make the merged **.shp** file available into `customised_data_dir`.
 
 
+### Stream data using a generator 
+
+For large files it is often not ideal to store the parsed data in-memory. You can stream the parsed data from a `*.osm.pbf` file by doing the following: 
+
+```python
+stream_data = stream_osm_pbf('/algeria.osm.pbf', 'lines') #pass the path to your *.osm.pbf file, and the layer that you want to parse/stream
+    
+for row in stream_data: 
+    do_something(row)
+```
 
 ### Import and retrieve data with a PostgreSQL server <a name="import-retrieve-data"></a>
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,4 @@ SQLAlchemy-Utils>=0.34.1
 tqdm>=4.32.2
 xlrd>=1.2.0
 XlsxWriter>=1.1.8
+flatten_json>=0.1.7


### PR DESCRIPTION
fixes #2 
- Added `stream_osm_pbf()` generator that returns iterator with parsed data 
- Updated `requirements.txt` accordingly 
- Updated `README.md` accordingly 

Note: This function streams layer-specific data. The reason for this was due to the fact that you may often want to stream data to a database, and each layer has a different schema, so for consistency sake I made it layer-specific. 