### PR TITLE
Fix `NoneType` error and improve layer parsing during OSM import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,7 @@ cov_reports/
 dist/
 *.egg-info/
 
-# Bespoke items
+# Project-specific directories / files
 *[!_]_.py
 pydriosm/data/*
 !.metadata

--- a/pydriosm/ios/_base.py
+++ b/pydriosm/ios/_base.py
@@ -411,6 +411,7 @@ class BaseIOS(PostgreSQL):
 
     def get_table_column_info(self, subregion_name, layer_name, as_dict=False,
                               table_named_as_subregion=False, schema_named_as_layer=False):
+        # noinspection PyUnresolvedReferences
         """
         Get information about columns of a specific schema and table data of a geographic (sub)region.
 
@@ -484,6 +485,7 @@ class BaseIOS(PostgreSQL):
                          table_named_as_subregion=False, schema_named_as_layer=False,
                          if_exists='fail', force_replace=False, chunk_size=None,
                          confirmation_required=True, verbose=False, **kwargs):
+        # noinspection PyUnresolvedReferences
         """
         Import one layer of OSM data into a table.
 
@@ -704,6 +706,7 @@ class BaseIOS(PostgreSQL):
                         table_named_as_subregion=False, schema_named_as_layer=False,
                         if_exists='fail', force_replace=False, chunk_size=None,
                         confirmation_required=True, verbose=False, raise_error=True, **kwargs):
+        # noinspection PyUnresolvedReferences
         """
         Import OSM data into a database.
 
@@ -918,51 +921,54 @@ class BaseIOS(PostgreSQL):
             subregion_name=table_name, table_named_as_subregion=table_named_as_subregion)
         tbl_name = f'"{table_name_}"'
 
-        if confirmed(f"Proceed to import data into the table {tbl_name} at {self.address}\n?",
-                     confirmation_required=confirmation_required):
-
+        if not confirmed(f"Proceed to import data into the table {tbl_name} at {self.address}\n?",
+                         confirmation_required=confirmation_required):
             if verbose:
-                status_msg = "Importing the data"
-                if not confirmation_required:
-                    status_msg += f" into the table {tbl_name}"
-                    if verbose != 2:
-                        status_msg += f" at {self.address}"
-                print(status_msg, end=" ... \n")
+                print("Canceled.")
+            return None
 
-            for geom_type, osm_layer in data_items:
+        if verbose:
+            status_msg = "Importing the data"
+            if not confirmation_required:
+                status_msg += f" into the table {tbl_name}"
+                if verbose != 2:
+                    status_msg += f" at {self.address}"
+            print(status_msg, end=" ... \n")
+
+        for geom_type, osm_layer in data_items:
+            if verbose:
+                print(f'  "{geom_type}"', end=" ... ")
+
+                if osm_layer is None or osm_layer.empty:
+                    print("Skipped (Empty).")
+                    continue
+
+            try:
+                import_args = {
+                    'layer_data': osm_layer,
+                    'schema_name': geom_type,
+                    'table_name': table_name_,
+                    'table_named_as_subregion': table_named_as_subregion,
+                    'schema_named_as_layer': schema_named_as_layer,
+                    'if_exists': if_exists,
+                    'force_replace': force_replace,
+                    'chunk_size': chunk_size,
+                    'confirmation_required': False,
+                    'verbose': False,
+                }
+                kwargs.update(import_args)
+                self.import_osm_layer(**kwargs)
+
                 if verbose:
-                    print(f'  "{geom_type}"', end=" ... ")
+                    print(f"Done. ({len(osm_layer)} features)")
 
-                    if len(osm_layer) == 0:
-                        print("The layer is empty. "
-                              "The corresponding table in the database is thus empty.")
+            except Exception as e:
+                _print_failure_message(
+                    e, prefix=f"Failed on the layer '{geom_type}'", verbose=verbose,
+                    raise_error=raise_error)
 
-                try:
-                    import_args = {
-                        'layer_data': osm_layer,
-                        'schema_name': geom_type,
-                        'table_name': table_name_,
-                        'table_named_as_subregion': table_named_as_subregion,
-                        'schema_named_as_layer': schema_named_as_layer,
-                        'if_exists': if_exists,
-                        'force_replace': force_replace,
-                        'chunk_size': chunk_size,
-                        'confirmation_required': False,
-                        'verbose': False,
-                    }
-                    kwargs.update(import_args)
-                    self.import_osm_layer(**kwargs)
-
-                    if verbose:
-                        print(f"Done. ({len(osm_layer)} features)")
-
-                except Exception as e:
-                    _print_failure_message(
-                        e, prefix=f'Failed on the layer "{geom_type}"', verbose=verbose,
-                        raise_error=raise_error)
-
-                del osm_layer
-                gc.collect()
+            del osm_layer
+            gc.collect()
 
     @staticmethod
     def _decode_layer_dat(dat, possible_col_names):
@@ -996,9 +1002,11 @@ class BaseIOS(PostgreSQL):
         # Validate the input `schema_names`
         if schema_names is None:
             inspector = sqlalchemy.inspection.inspect(self.engine)
+            # noinspection PyUnresolvedReferences
             schema_names_ = [
                 x for x in inspector.get_schema_names()
-                if x not in {'public', 'information_schema'}]
+                if x not in {'public', 'information_schema'}
+            ]
         else:
             schema_names_ = validate_schema_names(
                 schema_names=schema_names, schema_named_as_layer=schema_named_as_layer)

--- a/pydriosm/ios/_base.py
+++ b/pydriosm/ios/_base.py
@@ -939,7 +939,7 @@ class BaseIOS(PostgreSQL):
             if verbose:
                 print(f'  "{geom_type}"', end=" ... ")
 
-                if osm_layer is None or osm_layer.empty:
+                if osm_layer is None or len(osm_layer) == 0:
                     print("Skipped (Empty).")
                     continue
 

--- a/pydriosm/reader/_shp.py
+++ b/pydriosm/reader/_shp.py
@@ -38,20 +38,23 @@ def get_layer_name(shp_filename):
         'railways'
         >>> SHP.get_layer_name("gis_osm_transport_a_free_1.shp")
         'transport'
+        >>> SHP.get_layer_name("gis_osm_protected_areas_a_free_1.shp")
+        'protected_areas'
     """
 
-    try:
-        pattern = re.compile(r'(?<=gis_osm_)\w+(?=(_a)?_free_1)')
-        layer_name = re.search(pattern=pattern, string=shp_filename)
+    if not shp_filename:
+        return None
 
-    except AttributeError:
-        pattern = re.compile(r'(?<=(\\shape)\\)\w+(?=\.*)')
-        layer_name = re.search(pattern=pattern, string=shp_filename)
+    # The pattern captures everything between 'gis_osm_' and the suffix,
+    # then specifically strips the '_a' if it is there.
+    # pattern = re.compile(r'gis_osm_(.*?)_?a?_free_1(?:\.[a-z0-9]+)?$', re.IGNORECASE)
+    pattern = re.compile(r'^gis_osm_(.*?)(?=_?a?_free_1)', re.IGNORECASE)
+    match = re.search(pattern, shp_filename)
 
-    if layer_name:
-        layer_name = layer_name.group(0).replace("_a", "")
+    if match:
+        return match.group(1)
 
-    return layer_name
+    return None
 
 
 def _unzip_prep(shp_zip_pathname, extract_to=None, layer_names=None, verbose=False):
@@ -191,6 +194,7 @@ class SHP:
 
     #: Valid layer names for an OSM shapefile.
     LAYER_NAMES: set = {
+        'adminareas',
         'buildings',
         'landuse',
         'natural',
@@ -198,6 +202,7 @@ class SHP:
         'points',
         'pofw',
         'pois',
+        'protected_areas',
         'railways',
         'roads',
         'traffic',
@@ -939,6 +944,7 @@ class SHP:
     @classmethod
     def read_layer_shps(cls, shp_pathnames, feature_names=None, save_feat_shp=False,
                         ret_feat_shp_path=False, **kwargs):
+        # noinspection PyUnresolvedReferences
         """
         Read a layer of OSM shapefile data.
 
@@ -1126,25 +1132,27 @@ class SHP:
                     filename=out_fn, driver=cls.VECTOR_DRIVER, crs=cls.EPSG4326_WGS84_PROJ4)
 
         else:  # method == 'pyshp': (default)
-            kwargs.update({'ret_feat_shp_path': False})
+            kwargs.setdefault('ret_feat_shp_path', False)
             shp_data = cls.read_layer_shps(shp_pathnames, **kwargs)
-            if 'geometry' in shp_data.columns:
-                k = shp_data['geometry'].map(lambda x: x.geom_type)
-            else:
-                k = 'shape_type'
 
-            for geo_typ, dat in shp_data.groupby(k):
-                if isinstance(k, str):
-                    geo_typ = cls.SHAPE_TYPE_GEOM_NAME[geo_typ]
-                out_fn = os.path.join(path_to_merged_dir, f"{geo_typ.lower()}.shp")
-                cls.write_to_shapefile(data=dat, write_to=out_fn)
+            if isinstance(shp_data, pd.DataFrame):
+                if 'geometry' in shp_data.columns:
+                    k = shp_data['geometry'].map(lambda x: x.geom_type)
+                else:
+                    k = 'shape_type'
 
-                # Write .cpg
-                with open(out_fn.replace(".shp", ".cpg"), mode="w") as cpg:
-                    cpg.write(cls.ENCODING)
-                # Write .prj
-                with open(out_fn.replace(".shp", ".prj"), mode="w") as prj:
-                    prj.write(cls.EPSG4326_WGS84_ESRI_WKT)
+                for geo_typ, dat in shp_data.groupby(k):
+                    if isinstance(k, str):
+                        geo_typ = cls.SHAPE_TYPE_GEOM_NAME[geo_typ]
+                    out_fn = os.path.join(path_to_merged_dir, f"{geo_typ.lower()}.shp")
+                    cls.write_to_shapefile(data=dat, write_to=out_fn)
+
+                    # Write .cpg
+                    with open(out_fn.replace(".shp", ".cpg"), mode="w") as cpg:
+                        cpg.write(cls.ENCODING)
+                    # Write .prj
+                    with open(out_fn.replace(".shp", ".prj"), mode="w") as prj:
+                        prj.write(cls.EPSG4326_WGS84_ESRI_WKT)
 
     @classmethod
     def _extract_files(cls, shp_zip_pathnames, layer_name, verbose=False):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,3 +47,8 @@ classifiers = [
 
 [tool.setuptools]
 packages = { find = {} }
+
+[tool.pydocstyle]
+convention = "pep257"
+add-ignore = ["D212"]
+add-select = ["D213"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,5 +50,5 @@ packages = { find = {} }
 
 [tool.pydocstyle]
 convention = "pep257"
-add-ignore = ["D212"]
+add-ignore = ["D200", "D212"]
 add-select = ["D213"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,8 +47,3 @@ classifiers = [
 
 [tool.setuptools]
 packages = { find = {} }
-
-[tool.pydocstyle]
-convention = "pep257"
-add-ignore = ["D200", "D212"]
-add-select = ["D213"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "pyhelpers >= 2.3.4",
     "pyrcs >= 1.0.4",
     "pyshp >= 3.0.3",
-    "pandas >= 3.0.0"
+    "pandas >= 3.0.2"
 ]
 classifiers = [
     "Intended Audience :: Developers",

--- a/tests/test__updater_.py
+++ b/tests/test__updater_.py
@@ -1,6 +1,4 @@
-"""
-Tests the module: :mod:`pydriosm._updater`.
-"""
+"""Tests the module: :mod:`pydriosm._updater`."""
 
 import pytest
 

--- a/tests/test__updater_.py
+++ b/tests/test__updater_.py
@@ -1,4 +1,6 @@
-"""Test the module :py:mod:`pydriosm._updater`."""
+"""
+Tests the module: :mod:`pydriosm._updater`.
+"""
 
 import pytest
 

--- a/tests/test_downloader/test__base.py
+++ b/tests/test_downloader/test__base.py
@@ -1,7 +1,3 @@
-"""
-Tests the :py:mod:`pydriosm.downloader._downloader` module.
-"""
-
 import copy
 import os
 

--- a/tests/test_downloader/test__bbbike.py
+++ b/tests/test_downloader/test__bbbike.py
@@ -1,5 +1,5 @@
 """
-Tests the :py:class:`pydriosm.downloader._bbbike.BBBikeDownloader` class.
+Tests the class: :class:`pydriosm.downloader._bbbike.BBBikeDownloader`.
 """
 
 import os

--- a/tests/test_downloader/test__bbbike.py
+++ b/tests/test_downloader/test__bbbike.py
@@ -1,6 +1,4 @@
-"""
-Tests the class: :class:`pydriosm.downloader._bbbike.BBBikeDownloader`.
-"""
+"""Tests the class: :class:`pydriosm.downloader._bbbike.BBBikeDownloader`."""
 
 import os
 

--- a/tests/test_downloader/test__geofabrik.py
+++ b/tests/test_downloader/test__geofabrik.py
@@ -1,5 +1,5 @@
 """
-Tests the :py:class:`pydriosm.downloader._geofabrik.GeofabrikDownloader` class.
+Tests the class: :class:`pydriosm.downloader._geofabrik.GeofabrikDownloader`.
 """
 
 import os

--- a/tests/test_downloader/test__geofabrik.py
+++ b/tests/test_downloader/test__geofabrik.py
@@ -1,6 +1,4 @@
-"""
-Tests the class: :class:`pydriosm.downloader._geofabrik.GeofabrikDownloader`.
-"""
+"""Tests the class: :class:`pydriosm.downloader._geofabrik.GeofabrikDownloader`."""
 
 import os
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,6 +1,4 @@
-"""
-Tests the module: :mod:`pydriosm.errors`.
-"""
+"""Tests the module: :mod:`pydriosm.errors`."""
 
 import pytest
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,5 +1,5 @@
 """
-Test the module :py:mod:`pydriosm.errors`.
+Tests the module: :mod:`pydriosm.errors`.
 """
 
 import pytest

--- a/tests/test_ios/test_utils.py
+++ b/tests/test_ios/test_utils.py
@@ -1,13 +1,13 @@
 """
-Test the module :py:mod:`pydriosm.ios.utils`.
+Tests the submodule: :mod:`pydriosm.ios.utils`.
 """
 
 import pytest
 
+from pydriosm.ios.utils import get_default_layer_name, validate_schema_names, validate_table_name
+
 
 def test_get_default_layer_name():
-    from pydriosm.ios.utils import get_default_layer_name
-
     lyr_name = get_default_layer_name(schema_name='point')
     assert lyr_name == 'points'
 
@@ -16,8 +16,6 @@ def test_get_default_layer_name():
 
 
 def test_validate_schema_names():
-    from pydriosm.ios.utils import validate_schema_names
-
     valid_names = validate_schema_names()
     assert valid_names == []
 
@@ -30,8 +28,6 @@ def test_validate_schema_names():
 
 
 def test_validate_table_name():
-    from pydriosm.ios.utils import validate_table_name
-
     subrgn_name = 'greater london'
     valid_table_name = validate_table_name(subrgn_name)
     assert valid_table_name == 'greater london'
@@ -39,32 +35,6 @@ def test_validate_table_name():
     subrgn_name = 'Llanfairpwllgwyngyllgogerychwyrndrobwllllantysiliogogogoch, Wales'
     valid_table_name = validate_table_name(subrgn_name, sub_space='_')
     assert valid_table_name == 'Llanfairpwllgwyngyllgogerychwyrndrobwllllantysiliogogogoch_W..'
-
-
-# from pydriosm.ios import PostgresOSM
-# from pydriosm.downloader import GeofabrikDownloader, BBBikeDownloader
-# from pydriosm.reader import GeofabrikReader, BBBikeReader
-#
-#
-# osmdb = PostgresOSM(database_name='osmdb_test')
-#
-#
-# class TestPostgresOSM:
-#
-#     @staticmethod
-#     def test_init():
-#         assert osmdb.data_source == 'Geofabrik'
-#         assert osmdb.name == 'Geofabrik OpenStreetMap data extracts'
-#         assert osmdb.url == 'https://download.geofabrik.de/'
-#         assert isinstance(osmdb.downloader, GeofabrikDownloader)
-#         assert isinstance(osmdb.reader, GeofabrikReader)
-#
-#         # Change the data source
-#         assert osmdb.data_source == 'BBBike'
-#         assert osmdb.name == 'BBBike exports of OpenStreetMap data'
-#         assert osmdb.url == 'https://download.bbbike.org/osm/bbbike/'
-#         assert isinstance(osmdb.downloader, BBBikeDownloader)
-#         assert isinstance(osmdb.reader, BBBikeReader)
 
 
 if __name__ == '__main__':

--- a/tests/test_ios/test_utils.py
+++ b/tests/test_ios/test_utils.py
@@ -1,6 +1,4 @@
-"""
-Tests the submodule: :mod:`pydriosm.ios.utils`.
-"""
+"""Tests the submodule: :mod:`pydriosm.ios.utils`."""
 
 import pytest
 

--- a/tests/test_reader/test__base.py
+++ b/tests/test_reader/test__base.py
@@ -1,7 +1,3 @@
-"""
-Tests the submodule: :py:mod:`pydriosm.reader._reader`.
-"""
-
 import os
 
 import pytest

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,4 @@
-"""
-Tests the module: :mod:`pydriosm.utils`.
-"""
+"""Tests the module: :mod:`pydriosm.utils`."""
 
 import os
 import shutil

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,6 @@
-"""Test the module :py:mod:`pydriosm.utils`."""
+"""
+Tests the module: :mod:`pydriosm.utils`.
+"""
 
 import os
 import shutil


### PR DESCRIPTION
### Summary

This PR addresses a `TypeError` occurring when importing OSM data where certain layers (specifically shapefiles e.g. `protected_areas`) returned `None` or were empty. It also standardises the regex for layer name extraction to handle multi-word layer names and multiple file extensions.

### Changes

- **Bug fixes**: 
  - Added `None` and length checks in `import_osm_data()` to safely skip empty layers.
  - Switched from `.empty` back to `len()` to maintain compatibility with both DataFrames and lists.
- **Refactoring**: 
  - Improved `get_layer_name` regex using non-greedy lookaheads to correctly identify complex layer names (e.g. `protected_areas`).
- **Environment**: 
  - Bumped minimum `pandas` version to `3.0.2` to avoid regressions found in earlier versions.
- **Documentation & maintenance**: 
  - Standardised test suite headers and clarified `.gitignore` comments.

Resolves #38
