### PR TITLE
Fix broken BBBike city list retrieval (#42)

### DIFF
--- a/pydriosm/downloader/_bbbike.py
+++ b/pydriosm/downloader/_bbbike.py
@@ -103,6 +103,7 @@ class BBBikeDownloader(BaseDownloader):
     @classmethod
     def get_bbbike_cities(cls, update=False, confirmation_required=True, verbose=False,
                           raise_error=False):
+        # noinspection PyUnresolvedReferences
         """
         Get the names of all the available cities.
 
@@ -123,22 +124,23 @@ class BBBikeDownloader(BaseDownloader):
 
             >>> from pydriosm.downloader import BBBikeDownloader
             >>> bbd = BBBikeDownloader()
-            >>> bbbike_cities_names = bbd.get_bbbike_cities()
-            >>> type(bbbike_cities_names)
-            list
+            >>> bbbike_cities = bbd.get_bbbike_cities()
+            >>> bbbike_cities[:5]
+            ['Aachen', 'Aarhus', 'Adelaide', 'Albuquerque', 'Alexandria']
         """
 
         data_name = f'{cls.NAME} cities'
 
-        cities_names = cls.get_prepacked_data(
-            fetch_bbbike_cities, url=cls.CITIES_URL, data_name=data_name, update=update,
+        cities = cls.get_prepacked_data(
+            fetch_bbbike_cities, url=cls.URL, data_name=data_name, update=update,
             confirmation_required=confirmation_required, verbose=verbose, raise_error=raise_error)
 
-        return cities_names
+        return cities
 
     @classmethod
     def get_coordinates_of_cities(cls, update=False, confirmation_required=True, verbose=False,
                                   raise_error=False):
+        # noinspection PyUnresolvedReferences
         """
         Get location information of all cities available on the download server.
 
@@ -201,7 +203,7 @@ class BBBikeDownloader(BaseDownloader):
     @classmethod
     def get_subregion_index(cls, update=False, confirmation_required=True, verbose=False,
                             raise_error=False):
-        # noinspection PyShadowingNames
+        # noinspection PyShadowingNames,PyUnresolvedReferences
         """
         Get a catalogue for geographic (sub)regions.
 
@@ -335,7 +337,7 @@ class BBBikeDownloader(BaseDownloader):
 
     def get_sub_catalogue(self, subregion_name, update=False, confirmation_required=True,
                           verbose=False, raise_error=False):
-        # noinspection PyShadowingNames
+        # noinspection PyShadowingNames,PyUnresolvedReferences
         """
         Get a download catalogue of OSM data available for a given geographic (sub)region.
 
@@ -393,6 +395,7 @@ class BBBikeDownloader(BaseDownloader):
     @classmethod
     def get_catalogue(cls, update=False, confirmation_required=True, verbose=False,
                       raise_error=False):
+        # noinspection PyUnresolvedReferences
         """
         Get a dict-type index of available formats, data types and a download catalogue.
 

--- a/pydriosm/downloader/web_parser.py
+++ b/pydriosm/downloader/web_parser.py
@@ -595,27 +595,64 @@ def fetch_valid_geofabrik_subregion_names():
 # == BBBike ========================================================================================
 
 
-def fetch_bbbike_cities(url):
+def fetch_bbbike_cities(url, raise_error=True):
+    # noinspection PyShadowingNames
     """
     Fetches the names of all the available cities.
 
     :return: list of names of cities available on BBBike free download server
     :rtype: list
 
-    url = 'https://raw.githubusercontent.com/wosch/bbbike-world/world/etc/cities.txt'
+    .. note::
 
+        - This function is used internally by
+          :meth:`BBBikeDownloader.get_bbbike_cities
+          <pydriosm.downloader.BBBikeDownloader.get_bbbike_cities>`, which uses
+          :attr:`BBBikeDownloader.URL<pydriosm.downloader.BBBikeDownloader.URL>`
+          as the default ``url``.
+        - The ``url`` used to default to
+          ``'https://raw.githubusercontent.com/wosch/bbbike-world/world/etc/cities.txt'``, which
+          has been unavailable.
+
+    **Examples**::
+
+        >>> from pydriosm.downloader.web_parser import fetch_bbbike_cities
+        >>> url = 'https://download.bbbike.org/osm/bbbike/'
+        >>> cities = fetch_bbbike_cities(url)
 
     .. seealso::
 
-        - Examples for the method
-          :meth:`~pydriosm.downloader.BBBikeDownloader.get_names_of_cities`.
+        - Examples for :meth:`~pydriosm.downloader.BBBikeDownloader.get_bbbike_cities`.
     """
 
-    names_of_cities_ = pd.read_csv(url, header=None)
+    try:  # url = 'https://download.bbbike.org/osm/bbbike/'
+        response = requests.get(url, headers=fake_requests_headers(), timeout=10)
+        if raise_error:
+            response.raise_for_status()
+        elif not response.ok:
+            return []  # Return empty list if we shouldn't raise error
 
-    names_of_cities = list(names_of_cities_.values.flatten())
+        soup = bs4.BeautifulSoup(response.content, features='html.parser')
+    except Exception as e:
+        if raise_error:
+            raise e
+        return []
 
-    return names_of_cities
+    # Find the table or the specific links directly
+    links = soup.find_all('a')  # Directory listings are consistently <a> tags inside <tr> or <td>
+
+    if not links and raise_error:
+        raise ValueError(
+            f"Could not find any links at '{url}'. The page structure might have changed.")
+
+    cities = []
+    for a in links:
+        text = a.get_text(strip=True)
+        # Filter: Must have text; Not parent dir
+        if text and not text.startswith((".", "Parent")):
+            cities.append(text.rstrip("/"))
+
+    return cities
 
 
 def fetch_bbbike_city_coordinates(url, raise_error=True):

--- a/tests/test_downloader/test__bbbike.py
+++ b/tests/test_downloader/test__bbbike.py
@@ -29,10 +29,10 @@ class TestBBBikeDownloader:
         assert isinstance(bbd.subregion_index, pd.DataFrame)
         assert isinstance(bbd.catalogue, dict)
 
-    # @pytest.mark.parametrize('update', [True, False])
-    def test_get_names_of_cities(self, bbd, monkeypatch, capfd):
+    @pytest.mark.parametrize('update', [True, False])
+    def test_get_bbbike_cities(self, bbd, update, monkeypatch, capfd):
         monkeypatch.setattr('builtins.input', lambda _: "Yes")
-        bbbike_cities = bbd.get_bbbike_cities(update=False, verbose=True)
+        bbbike_cities = bbd.get_bbbike_cities(update=update, verbose=True)
         out, _ = capfd.readouterr()
         # if update:
         #     assert "Retrieving/compiling the data" in out and "Done." in out


### PR DESCRIPTION
### Summary

This PR addresses the 404 error encountered when fetching available cities from the BBBike downloader. The source has transitioned from a static GitHub-hosted text file to a dynamic directory index scraping method to ensure long-term availability.

### Changes

- **Fix (`web_parser`)**: Updated `fetch_bbbike_cities()` to parse the BBBike directory index using `BeautifulSoup` instead of relying on a missing CSV/text file.
- **Refactor**: Redirected internal logic to use `BBBikeDownloader.URL` as the primary source of truth.
- **Testing**: Updated `test_get_bbbike_cities()` to validate the new scraping logic.

### Fixes

Closes #42 