### PR TITLE
Migrate BBBike city coordinates to .poly scraping (#44)

### DIFF
--- a/pydriosm/downloader/_bbbike.py
+++ b/pydriosm/downloader/_bbbike.py
@@ -10,7 +10,7 @@ from pyhelpers.ops import confirmed
 
 from pydriosm.downloader._base import BaseDownloader
 from pydriosm.downloader.web_parser import fetch_bbbike_catalogue, fetch_bbbike_cities, \
-    fetch_bbbike_city_coordinates, fetch_bbbike_sub_catalogue, fetch_bbbike_subregion_index, \
+    fetch_bbbike_city_polygons, fetch_bbbike_sub_catalogue, fetch_bbbike_subregion_index, \
     fetch_bbbike_valid_subregion_names
 
 
@@ -29,9 +29,6 @@ class BBBikeDownloader(BaseDownloader):
 
     #: URL of the homepage to the free download server.
     URL: str = 'https://download.bbbike.org/osm/bbbike/'
-
-    #: URL of coordinates of all the available cities.
-    CITIES_COORDS_URL: str = 'https://raw.githubusercontent.com/wosch/bbbike-world/world/etc/cities.csv'
 
     #: Default download directory.
     DEFAULT_DOWNLOAD_DIR: str = "osm_data/bbbike"
@@ -92,7 +89,7 @@ class BBBikeDownloader(BaseDownloader):
         kwargs.update({'update': update})
 
         self.valid_subregion_names = self.get_bbbike_cities(**kwargs)
-        self.subregion_coordinates = self.get_coordinates_of_cities(**kwargs)
+        self.subregion_coordinates = self.get_bbbike_city_polygons(**kwargs)
         self.subregion_index = self.get_subregion_index(**kwargs)
         self.catalogue = self.get_catalogue(**kwargs)
         # self.valid_file_formats = set(self.catalogue['FileFormat'])
@@ -135,8 +132,8 @@ class BBBikeDownloader(BaseDownloader):
         return cities
 
     @classmethod
-    def get_coordinates_of_cities(cls, update=False, confirmation_required=True, verbose=False,
-                                  raise_error=False):
+    def get_bbbike_city_polygons(cls, update=False, confirmation_required=True, verbose=False,
+                                 raise_error=False):
         # noinspection PyUnresolvedReferences
         """
         Get location information of all cities available on the download server.
@@ -158,40 +155,24 @@ class BBBikeDownloader(BaseDownloader):
 
             >>> from pydriosm.downloader import BBBikeDownloader
             >>> bbd = BBBikeDownloader()
-            >>> # Location information of BBBike cities
-            >>> coords_of_cities = bbd.get_coordinates_of_cities()
-            >>> type(coords_of_cities)
-            pandas.core.frame.DataFrame
-            >>> coords_of_cities.shape
-            (240, 13)
-            >>> coords_of_cities.head()
-                      City  ... ur_latitude
-            0       Aachen  ...       50.99
-            1       Aarhus  ...      56.287
-            2     Adelaide  ...     -34.753
-            3  Albuquerque  ...     35.2173
-            4   Alexandria  ...       31.34
-            [5 rows x 13 columns]
-            >>> coords_of_cities.columns.to_list()
-            ['city',
-             'real_name',
-             'pref._language',
-             'local_language',
-             'country',
-             'area_or_continent',
-             'population',
-             'step',
-             'other_cities',
-             'll_longitude',
-             'll_latitude',
-             'ur_longitude',
-             'ur_latitude']
+            >>> bbbike_city_polygons = bbd.get_bbbike_city_polygons()
+            >>> type(bbbike_city_polygons)
+            pandas.DataFrame
+            >>> bbbike_city_polygons.shape
+            (238, 2)
+            >>> bbbike_city_polygons.head()
+                      name                                           geometry
+            0       Aachen  POLYGON ((5.88 50.6, 6.58 50.6, 6.58 50.99, 5....
+            1       Aarhus  POLYGON ((9.82 55.99, 10.37 55.99, 10.37 56.29...
+            2     Adelaide  POLYGON ((138.46 -35.03, 138.74 -35.03, 138.74...
+            3  Albuquerque  POLYGON ((-106.8 35, -106.47 35, -106.47 35.22...
+            4   Alexandria  POLYGON ((29.7 31.02, 30.21 31.02, 30.21 31.34...
         """
 
-        data_name = f'{cls.NAME} cities coordinates'
+        data_name = f'{cls.NAME} cities poly'
 
         cities_coords = cls.get_prepacked_data(
-            fetch_bbbike_city_coordinates, url=cls.CITIES_COORDS_URL, raise_error=raise_error,
+            fetch_bbbike_city_polygons, url=cls.URL, raise_error=raise_error,
             data_name=data_name, update=update, confirmation_required=confirmation_required,
             verbose=verbose)
 

--- a/pydriosm/downloader/_bbbike.py
+++ b/pydriosm/downloader/_bbbike.py
@@ -30,9 +30,6 @@ class BBBikeDownloader(BaseDownloader):
     #: URL of the homepage to the free download server.
     URL: str = 'https://download.bbbike.org/osm/bbbike/'
 
-    #: URL of a list of cities that are available on the free download server.
-    CITIES_URL: str = 'https://raw.githubusercontent.com/wosch/bbbike-world/world/etc/cities.txt'
-
     #: URL of coordinates of all the available cities.
     CITIES_COORDS_URL: str = 'https://raw.githubusercontent.com/wosch/bbbike-world/world/etc/cities.csv'
 

--- a/pydriosm/downloader/_wrapper.py
+++ b/pydriosm/downloader/_wrapper.py
@@ -1076,8 +1076,9 @@ class Downloader(BaseDownloader):
         else:
             self._raise_unavailable_method_error(method_name=method_name, raise_error=raise_error)
 
-    def get_coordinates_of_cities(self, update=False, confirmation_required=True, verbose=False,
-                                  raise_error=True):
+    def get_bbbike_city_polygons(self, update=False, confirmation_required=True, verbose=False,
+                                 raise_error=True):
+        # noinspection PyUnresolvedReferences
         """
         Get location information of all cities available on the download server.
 
@@ -1099,37 +1100,24 @@ class Downloader(BaseDownloader):
             >>> from pydriosm.downloader import Downloader
             >>> downloader = Downloader(data_source='bbbike')
             >>> # Location information of BBBike cities
-            >>> coords_of_cities = downloader.get_coordinates_of_cities()
-            >>> type(coords_of_cities)
-            pandas.core.frame.DataFrame
-            >>> coords_of_cities.head()
-                      City  ... ur_latitude
-            0       Aachen  ...       50.99
-            1       Aarhus  ...      56.287
-            2     Adelaide  ...     -34.753
-            3  Albuquerque  ...     35.2173
-            4   Alexandria  ...       31.34
-            [5 rows x 13 columns]
-            >>> coords_of_cities.columns.to_list()
-            ['city',
-             'real_name',
-             'pref._language',
-             'local_language',
-             'country',
-             'area_or_continent',
-             'population',
-             'step',
-             'other_cities',
-             'll_longitude',
-             'll_latitude',
-             'ur_longitude',
-             'ur_latitude']
+            >>> bbbike_city_polygons = downloader.get_bbbike_city_polygons()
+            >>> type(bbbike_city_polygons)
+            pandas.DataFrame
+            >>> bbbike_city_polygons.shape
+            (238, 2)
+            >>> bbbike_city_polygons.head()
+                      name                                           geometry
+            0       Aachen  POLYGON ((5.88 50.6, 6.58 50.6, 6.58 50.99, 5....
+            1       Aarhus  POLYGON ((9.82 55.99, 10.37 55.99, 10.37 56.29...
+            2     Adelaide  POLYGON ((138.46 -35.03, 138.74 -35.03, 138.74...
+            3  Albuquerque  POLYGON ((-106.8 35, -106.47 35, -106.47 35.22...
+            4   Alexandria  POLYGON ((29.7 31.02, 30.21 31.02, 30.21 31.34...
         """
 
-        method_name = self.get_coordinates_of_cities.__name__
+        method_name = self.get_bbbike_city_polygons.__name__
 
         if hasattr(self.downloader, method_name):
-            return self.downloader.get_coordinates_of_cities(
+            return self.downloader.get_bbbike_city_polygons(
                 update=update,
                 confirmation_required=confirmation_required,
                 verbose=verbose,

--- a/pydriosm/downloader/web_parser.py
+++ b/pydriosm/downloader/web_parser.py
@@ -4,7 +4,6 @@
 
 import collections
 import concurrent.futures
-import csv
 import json
 import os
 import re
@@ -724,6 +723,7 @@ def fetch_bbbike_subregion_index(url, raise_error=True):
           :meth:`~pydriosm.downloader.BBBikeDownloader.get_subregion_index`.
     """
 
+    # url='https://download.bbbike.org/osm/bbbike/'
     with requests.get(url, headers=fake_requests_headers()) as response:
         if raise_error:
             response.raise_for_status()
@@ -745,6 +745,60 @@ def fetch_bbbike_subregion_index(url, raise_error=True):
     data['url'] = [urllib.parse.urljoin(url, x.get('href')) for x in soup.find_all('a')[1:]]
 
     return data
+
+
+def fetch_bbbike_city_poly(poly_url, raise_error=True):
+    # noinspection PyShadowingNames
+    """
+    Fetches and parses a .poly file from BBBike to a shapely Polygon.
+
+    :param poly_url: URL to the .poly file (e.g. from download.bbbike.org)
+    :type poly_url: str
+    :param raise_error: whether to raise an exception if the request fails, defaults to True
+    :type raise_error: bool
+    :return: a polygon representing the city's boundaries
+    :rtype: shapely.Polygon
+
+    **Examples**::
+
+        >>> from pydriosm.downloader.web_parser import get_bbbike_city_poly
+        >>> poly_url = 'https://download.bbbike.org/osm/bbbike/Aachen/Aachen.poly'
+        >>> aachen_poly = get_bbbike_city_poly(poly_url)
+        >>> type(aachen_poly)
+        shapely.geometry.polygon.Polygon
+        >>> print(aachen_poly)
+        POLYGON ((5.88 50.6, 6.58 50.6, 6.58 50.99, 5.88 50.99, 5.88 50.6))
+    """
+
+    # poly_url = 'https://download.bbbike.org/osm/bbbike/Aachen/Aachen.poly'
+    try:
+        response = requests.get(poly_url, headers=fake_requests_headers(), timeout=10)
+        if raise_error:
+            response.raise_for_status()
+        elif not response.ok:
+            return None
+
+        # Decode content and split into lines correctly
+        lines = response.content.decode('utf-8').splitlines()
+
+    except Exception as e:
+        if raise_error:
+            raise e
+        return None
+
+    # Osmosis polygon format:
+    # Line 0: Name, Line 1: Polygon ID, Line 2 to -2: Coords, Line -1: END
+    coords = []
+    for line in lines:
+        parts = line.strip().split()
+        # Only process lines that have exactly two numbers (Longitude and Latitude)
+        if len(parts) == 2:
+            try:
+                coords.append([float(x) for x in parts])
+            except ValueError:
+                continue  # Skip lines that aren't numeric (like the header or "END")
+
+    return shapely.geometry.Polygon(coords)  # (ll, lr, ur, ul)
 
 
 def fetch_bbbike_valid_subregion_names(cls_instance):

--- a/pydriosm/downloader/web_parser.py
+++ b/pydriosm/downloader/web_parser.py
@@ -654,55 +654,6 @@ def fetch_bbbike_cities(url, raise_error=True):
     return cities
 
 
-def fetch_bbbike_city_coordinates(url, raise_error=True):
-    """
-    Fetches location information of all cities available on the BBBike download server.
-
-    :return: location information of BBBike cities, i.e. geographic (sub)regions
-    :rtype: pandas.DataFrame
-
-    .. seealso::
-
-        - Examples for the method
-          :meth:`~pydriosm.downloader.BBBikeDownloader.get_coordinates_of_cities`.
-    """
-
-    # Fetch data from the URL
-    with requests.get(url, headers=fake_requests_headers()) as response:
-        if raise_error:
-            response.raise_for_status()
-        # Decode content and parse CSV
-        csv_data = response.content.decode('utf-8')
-        csv_reader = list(csv.reader(csv_data.splitlines(), delimiter=':'))
-
-    clean_data = [
-        [cell.strip().strip('\u200e').replace('#', '') for cell in row] for row in csv_reader[5:-1]
-    ]
-    column_names = [col.replace('#', '').strip().capitalize() for col in csv_reader[0]]
-    cities_coords = pd.DataFrame(clean_data, columns=column_names)
-
-    # Extract coordinates and assign proper column names
-    coord_cols = ['ll_longitude', 'll_latitude', 'ur_longitude', 'ur_latitude']
-    cities_coords[coord_cols] = cities_coords['Coord'].str.split(' ', expand=True)
-    cities_coords.drop(columns=['Coord'], inplace=True)
-
-    # Drop rows with missing coordinate values
-    cities_coords.dropna(subset=coord_cols, inplace=True)
-
-    # Process 'Real name' column
-    cities_coords['Real name'] = cities_coords['Real name'].str.split(r'[!,]').map(
-        lambda x: None if not x or x[0] == '' else dict(zip(x[::2], x[1::2]))
-    )
-
-    # Rename columns to lowercase with underscores
-    cities_coords.columns = [
-        col.replace(' ', '_').replace('/', '_or_').replace('?', '').replace('.', '').lower()
-        for col in cities_coords.columns
-    ]
-
-    return cities_coords
-
-
 def fetch_bbbike_subregion_index(url, raise_error=True):
     # noinspection PyShadowingNames
     """
@@ -799,6 +750,71 @@ def fetch_bbbike_city_poly(poly_url, raise_error=True):
                 continue  # Skip lines that aren't numeric (like the header or "END")
 
     return shapely.geometry.Polygon(coords)  # (ll, lr, ur, ul)
+
+
+def fetch_bbbike_city_coordinates(url, max_workers=10, raise_error=True):
+    # noinspection PyShadowingNames
+    """
+    Fetches poly information of all cities available on the BBBike download server.
+
+    :param url: The base URL of the BBBike download server.
+    :type url: str
+    :param max_workers: Number of parallel threads to use. Defaults to ``10``.
+    :type max_workers: int
+    :param raise_error: Whether to raise an exception if a request fails. Defaults to ``True``.
+    :type raise_error: bool
+    :return: A DataFrame containing poly information of BBBike cities, i.e. geographic (sub)regions.
+    :rtype: pandas.DataFrame
+
+    **Examples**::
+
+        >>> from pydriosm.downloader.web_parser import fetch_bbbike_city_coordinates
+        >>> url = 'https://download.bbbike.org/osm/bbbike/'
+        >>> bbbike_cities_poly = fetch_bbbike_city_coordinates(url)
+        >>> bbbike_cities_poly.head()
+                  name                                           geometry
+        0       Aachen  POLYGON ((5.88 50.6, 6.58 50.6, 6.58 50.99, 5....
+        1       Aarhus  POLYGON ((9.82 55.99, 10.37 55.99, 10.37 56.29...
+        2     Adelaide  POLYGON ((138.46 -35.03, 138.74 -35.03, 138.74...
+        3  Albuquerque  POLYGON ((-106.8 35, -106.47 35, -106.47 35.22...
+        4   Alexandria  POLYGON ((29.7 31.02, 30.21 31.02, 30.21 31.34...
+
+    .. seealso::
+
+        - Examples for the method
+          :meth:`~pydriosm.downloader.BBBikeDownloader.get_coordinates_of_cities`.
+    """
+
+    # Fetch the data of BBBike cities
+    subregion_index = fetch_bbbike_subregion_index(url=url, raise_error=raise_error)
+
+    if subregion_index is None:
+        return None
+
+    def _get_poly(row):
+        """Helper to construct URL and fetch the polygon."""
+        city_url = row['url']
+        city_name = city_url.rstrip('/').split('/')[-1]
+        poly_url = urllib.parse.urljoin(city_url, f"{city_name}.poly")
+
+        # Returns (index, polygon) to maintain order during threading
+        return row.name, fetch_bbbike_city_poly(poly_url, raise_error=False)
+
+    # Convert the DataFrame rows to a list of dicts/tuples for the executor
+    rows = [row for _, row in subregion_index.iterrows()]
+
+    results = []
+    with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
+        # map ensures we can process them as they complete
+        results = list(executor.map(_get_poly, rows))
+
+    # Reconstruct DataFrame, sorting it by index to ensure name and geometry match correctly
+    results.sort(key=lambda x: x[0])
+    geometries = [res[1] for res in results]
+
+    cities_poly = pd.DataFrame({'name': subregion_index['name'], 'geometry': geometries})
+
+    return cities_poly
 
 
 def fetch_bbbike_valid_subregion_names(cls_instance):

--- a/pydriosm/downloader/web_parser.py
+++ b/pydriosm/downloader/web_parser.py
@@ -752,7 +752,7 @@ def fetch_bbbike_city_poly(poly_url, raise_error=True):
     return shapely.geometry.Polygon(coords)  # (ll, lr, ur, ul)
 
 
-def fetch_bbbike_city_coordinates(url, max_workers=10, raise_error=True):
+def fetch_bbbike_city_polygons(url, max_workers=10, raise_error=True):
     # noinspection PyShadowingNames
     """
     Fetches poly information of all cities available on the BBBike download server.
@@ -768,9 +768,9 @@ def fetch_bbbike_city_coordinates(url, max_workers=10, raise_error=True):
 
     **Examples**::
 
-        >>> from pydriosm.downloader.web_parser import fetch_bbbike_city_coordinates
+        >>> from pydriosm.downloader.web_parser import fetch_bbbike_city_polygons
         >>> url = 'https://download.bbbike.org/osm/bbbike/'
-        >>> bbbike_cities_poly = fetch_bbbike_city_coordinates(url)
+        >>> bbbike_cities_poly = fetch_bbbike_city_polygons(url)
         >>> bbbike_cities_poly.head()
                   name                                           geometry
         0       Aachen  POLYGON ((5.88 50.6, 6.58 50.6, 6.58 50.99, 5....

--- a/tests/test_downloader/test__bbbike.py
+++ b/tests/test_downloader/test__bbbike.py
@@ -38,25 +38,12 @@ class TestBBBikeDownloader:
         #     assert "Retrieving/compiling the data" in out and "Done." in out
         assert isinstance(bbbike_cities, list)
 
-    # @pytest.mark.parametrize('update', [True, False])
-    def test_get_coordinates_of_cities(self, bbd, monkeypatch):
+    @pytest.mark.parametrize('update', [True, False])
+    def test_get_bbbike_city_polygons(self, bbd, update, monkeypatch):
         monkeypatch.setattr('builtins.input', lambda _: "Yes")
-        coords_of_cities = bbd.get_coordinates_of_cities(update=False, verbose=True)
-        assert isinstance(coords_of_cities, pd.DataFrame)
-        assert set(coords_of_cities.columns) == {
-            'city',
-            'real_name',
-            'pref_language',
-            'local_language',
-            'country',
-            'area_or_continent',
-            'population',
-            'step',
-            'other_cities',
-            'll_longitude',
-            'll_latitude',
-            'ur_longitude',
-            'ur_latitude'}
+        bbbike_city_polygons = bbd.get_bbbike_city_polygons(update=update, verbose=True)
+        assert isinstance(bbbike_city_polygons, pd.DataFrame)
+        assert set(bbbike_city_polygons.columns) == {'name', 'geometry'}
 
     @pytest.mark.parametrize('update', [True, False])
     def test_get_subregion_index(self, bbd, update, monkeypatch):


### PR DESCRIPTION
### Summary

This PR resolves the 404 error caused by the unavailability of the `cities.csv` source. The data retrieval logic has been updated to scrape individual `.poly` files directly from the BBBike server using multi-threading for improved performance.

### Changes

- **New feature**: Added `fetch_bbbike_city_poly()` to parse raw OSM polygon files into `shapely` objects.
- **Refactor**: 
  - Renamed coordinate-related functions to `*_polygons` for better technical accuracy.
  - Removed deprecated `CITIES_URL` and `CITIES_COORDS_URL` from `BBBikeDownloader`.
- **Testing**: Updated the test suite to validate the new geometry scraping logic and verify the multi-threaded output.

### Fixes

Closes #44